### PR TITLE
fixed database integration for local setup on windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.0.0'
 
-gem 'pg'
-
 # Use sqlite3 as the database for Active Record
 group :development, :test do
 	gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     mime-types (1.25.1)
     minitest (4.7.5)
     multi_json (1.11.0)
+    pg (0.18.1)
     pg (0.18.1-x86-mingw32)
     polyglot (0.3.5)
     rack (1.5.2)
@@ -95,6 +96,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    sqlite3 (1.3.10)
     sqlite3 (1.3.10-x86-mingw32)
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -110,6 +112,7 @@ GEM
       json (>= 1.8.0)
 
 PLATFORMS
+  ruby
   x86-mingw32
 
 DEPENDENCIES

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,23 +3,22 @@
 #
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
-development:
-  adapter: postgresql
-  database: db/development.sqlite3
+default: &default
+  adapter: sqlite3
   pool: 5
   timeout: 5000
+
+development:
+  <<: *default
+  database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: postgresql
+  <<: *default
   database: db/test.sqlite3
-  pool: 5
-  timeout: 5000
 
 production:
-  adapter: postgresql
+  <<: *default
   database: db/production.sqlite3
-  pool: 5
-  timeout: 5000


### PR DESCRIPTION
If you merge this into your own project, it should fix the database issues once you run `bundle install --without production` locally. From now on, that's what you'll have to run every time you `bundle install`.
